### PR TITLE
Freeze nltk and other ml/nlp libs versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "keras==2.3.1",
         "lazy",
         "nltk==3.5",
-        "numpy==1.20.1",
+        "numpy",
         "objgraph==3.4.1",
         "prometheus-client==0.7.1",
         "psutil==5.8.0",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 import versioneer
 
 
-with open("README.md", "r", encoding='utf-8') as file:
+with open("README.md", "r", encoding="utf-8") as file:
     long_description = file.read()
 
 setup(
@@ -20,45 +20,45 @@ setup(
     packages=find_packages(exclude=[]),
     include_package_data=True,
     install_requires=[
-        'h5py<3.0.0',
-        'tatsu==4.4.0',
-        'keras==2.3.1',
-        'tensorflow==1.15',
-        'nltk',
-        'rusenttokenize',
-        'rnnmorph',
-        "tqdm",
-        "tabulate",
+        "aiohttp==3.7.3",
+        "aioredis",
+        "boto==2.49.0",
+        "confluent_kafka==1.1.0",
+        "croniter",
+        "dawg==0.8.0",
+        "dill==0.3.3",
+        "h5py<3.0.0",
+        "ics==0.6",
+        "jaeger_client==4.3.0",
+        "Jinja2==2.10.1",
+        "keras==2.3.1",
         "lazy",
-        'setuptools',
-        'Jinja2==2.10.1',
-        'timeout-decorator==0.4.1',
-        'Twisted',
-        'confluent_kafka==1.1.0',
-        'pymorphy2==0.8',
-        'pymorphy2_dicts==2.4.393442.3710985',
-        'dawg==0.8.0',
-        'python-dateutil==2.7.3',
-        'ics==0.6',
-        'prometheus-client==0.7.1',
-        'boto==2.49.0',
-        'pyignite>=0.3.4',
-        'python-json-logger==0.1.11',
-        'PyYAML==5.3',
-        'requests==2.22.0',
-        'objgraph==3.4.1',
-        'psutil==5.8.0',
-        'jaeger_client==4.3.0',
-        'dill',
-        'redis',
-        'aiohttp==3.7.3',
-        'aioredis',
-        'croniter',
-        'numpy',
-        'scikit-learn==0.24.1'
+        "nltk==3.5",
+        "numpy==1.20.1",
+        "objgraph==3.4.1",
+        "prometheus-client==0.7.1",
+        "psutil==5.8.0",
+        "pyignite>=0.3.4",
+        "pymorphy2==0.8",
+        "pymorphy2_dicts==2.4.393442.3710985",
+        "python-dateutil==2.7.3",
+        "python-json-logger==0.1.11",
+        "PyYAML==5.3",
+        "redis",
+        "requests==2.22.0",
+        "rnnmorph==0.4.0",
+        "rusenttokenize==0.0.5",
+        "scikit-learn==0.24.1",
+        "setuptools",
+        "tabulate",
+        "tatsu==4.4.0",
+        "tensorflow==1.15",
+        "timeout-decorator==0.4.1",
+        "tqdm",
+        "Twisted"
     ],
     classifiers=[
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7"
     ]
 )


### PR DESCRIPTION
Зафиксировать стабильную рабочую версию либы `nltk==3.5` и парочки других библиотек, которые относятся к ml/nlp  
Ну и все зависимости были отсортированы в алфавитном порядке для красоты :) 
