### PR TITLE
Add changes to support vectorization in classifiers models

### DIFF
--- a/core/basic_models/classifiers/basic_classifiers.py
+++ b/core/basic_models/classifiers/basic_classifiers.py
@@ -9,6 +9,7 @@ from lazy import lazy
 from timeout_decorator import timeout_decorator
 
 import core.basic_models.classifiers.classifiers_constants as cls_const
+from core.basic_models.classifiers.vectorizer_models import vectorizers
 from core.model.factory import build_factory
 from core.model.registered import Registered
 from core.text_preprocessing.base import BaseTextPreprocessingResult
@@ -140,6 +141,7 @@ class ExtendedClassifier(Classifier):
         self.intents = self.settings["intents"]
         self._path = self.settings["path"]
         self._classifier = self.settings.get("classifier")
+        # Способ векторизации для реплик указывается в конфигурации классификатора
         self._vectorizer = self.settings.get("vectorizer")
 
     def set_classifier(self, clsf: Classifier) -> None:
@@ -155,10 +157,7 @@ class ExtendedClassifier(Classifier):
             mask: Optional[Dict[str, bool]] = None,
             scenario_classifiers: Optional[Dict[str, Any]] = None
     ) -> List[Dict[str, Union[str, float, bool]]]:
-        # TODO: позже здесь будут добавлены vectorizers, и возможность указывать способ векторизации в конфиге класси-ра
-        # vector = vectorizers[self._vectorizer].vectorize(text_preprocessing_result)
-        # if self._vectorizer else np.array([])
-        vector = np.array([])
+        vector = vectorizers[self._vectorizer].vectorize(text_preprocessing_result) if self._vectorizer else np.array([])
         weights = sorted(self._get_weights(text_preprocessing_result, vector).items(), key=lambda x: x[1], reverse=True)
         answers = []
         for weight in weights:

--- a/core/basic_models/classifiers/vectorizer_models.py
+++ b/core/basic_models/classifiers/vectorizer_models.py
@@ -1,0 +1,6 @@
+from core.model.factory import build_factory
+from core.model.registered import Registered
+
+vectorizers = Registered()
+
+vectorizer_factory = build_factory(vectorizers)


### PR DESCRIPTION
Добавлены небольшие изменения чтобы иметь возможность векторизировать реплики в классификаторах, посредством включения плагина `SAF Vectorizers`.

Как проверять этот PR:   
1) склонировать репо с плагином `https://github.com/sberdevices/saf_vectorizers`
2) активировать свой env и `установить туда saf_vectorizers` (см. раздел Установка в плагине): 
```
cd saf_vectorizers
pip install -e .
```
3) создать тестовый апп и прописать в конфиге: `PLUGINS = ["saf_vectorizers"]`
4) запустить local_testing у своего аппа: `python {YOUR_APP}/manage.py local_testing`
5) увидеть в логах консоли, что в момент инициализации аппа происходит инициализации и загрузка векторизаторов, тк подключён и используется плагин saf_vectorizers (имейте в виду, что инициализация и загрузка моделей занимает какое-то время).  

P.S. Ну и конечно смотреть и ревьюить сам плагин `SAF Vectorizers` :) 

P.S. Позже будут добавлены примеры моделей классификаторов, которые требуют векторизированнвые реплики на вход 
