### PR TITLE
moved .format variables to parameters dict

### DIFF
--- a/core/basic_models/actions/basic_actions.py
+++ b/core/basic_models/actions/basic_actions.py
@@ -29,9 +29,9 @@ class Action:
         raise NotImplementedError
 
     def on_run_error(self, text_preprocessing_result, user):
-        log("exc_handler: Action failed to run. Return None. MESSAGE: %(message_str)s.", user,
+        log("exc_handler: Action failed to run. Return None. MESSAGE: %(masked_message)s.", user,
             {log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE,
-             "message_str": user.message.masked_value},
+             "masked_message": user.message.masked_value},
             level="ERROR", exc_info=True)
         return None
 

--- a/core/basic_models/actions/basic_actions.py
+++ b/core/basic_models/actions/basic_actions.py
@@ -29,8 +29,9 @@ class Action:
         raise NotImplementedError
 
     def on_run_error(self, text_preprocessing_result, user):
-        log("exc_handler: Action failed to run. Return None. MESSAGE: {}.".format(user.message.masked_value), user,
-            {log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE},
+        log("exc_handler: Action failed to run. Return None. MESSAGE: %(message_str)s.", user,
+            {log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE,
+             "message_str": user.message.masked_value},
             level="ERROR", exc_info=True)
         return None
 

--- a/core/basic_models/requirement/basic_requirements.py
+++ b/core/basic_models/requirement/basic_requirements.py
@@ -43,8 +43,9 @@ class Requirement:
         return True
 
     def on_check_error(self, text_preprocessing_result, user):
-        log("exc_handler: Requirement failed to check. Return False. MESSAGE: {}.".format(user.message.masked_value),
-            user, {log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE},
+        log("exc_handler: Requirement failed to check. Return False. MESSAGE: %(message_str)s.",
+            user, {log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE,
+                   "message_str": user.message.masked_value},
             level="ERROR", exc_info=True)
         return False
 

--- a/core/basic_models/requirement/basic_requirements.py
+++ b/core/basic_models/requirement/basic_requirements.py
@@ -43,9 +43,9 @@ class Requirement:
         return True
 
     def on_check_error(self, text_preprocessing_result, user):
-        log("exc_handler: Requirement failed to check. Return False. MESSAGE: %(message_str)s.",
+        log("exc_handler: Requirement failed to check. Return False. MESSAGE: %(masked_message)s.",
             user, {log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE,
-                   "message_str": user.message.masked_value},
+                   "masked_message": user.message.masked_value},
             level="ERROR", exc_info=True)
         return False
 

--- a/core/unified_template/unified_template.py
+++ b/core/unified_template/unified_template.py
@@ -43,9 +43,10 @@ class UnifiedTemplate:
         try:
             result = self.silent_render(params_dict)
         except Exception:
-            log("Failed to render template: %(template)s with params {} ".format(str(params_dict)),
+            log("Failed to render template: %(template)s with params %(params_dict_str)s",
                 params={log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE,
-                          "template": str(self.input)},
+                          "template": str(self.input),
+                        "params_dict_str": str(params_dict)},
                 level="ERROR",
                 exc_info=True)
             monitoring.got_counter("core_jinja_template_error")

--- a/scenarios/scenario_descriptions/form_filling_scenario.py
+++ b/scenarios/scenario_descriptions/form_filling_scenario.py
@@ -53,8 +53,8 @@ class FormFillingScenario(BaseScenario):
             field = form.fields[field_name]
             if not field.valid and field.description.has_requests and \
                     field.description.requirement.check(
-                        text_preprocessing_result, user, params
-                    ):
+                    text_preprocessing_result, user, params
+            ):
                 return field
 
     def get_fields_data(self, form, form_key):
@@ -177,8 +177,7 @@ class FormFillingScenario(BaseScenario):
         logging_params.update(self._log_params())
         log("Extracted data=%(data_extracted_str)s", user, logging_params)
 
-        validation_error_msg = self._validate_extracted_data(user, text_preprocessing_result, form, data_extracted,
-                                                             params)
+        validation_error_msg = self._validate_extracted_data(user, text_preprocessing_result, form, data_extracted, params)
         if validation_error_msg:
             reply_messages = validation_error_msg
         else:

--- a/scenarios/scenario_descriptions/form_filling_scenario.py
+++ b/scenarios/scenario_descriptions/form_filling_scenario.py
@@ -53,8 +53,8 @@ class FormFillingScenario(BaseScenario):
             field = form.fields[field_name]
             if not field.valid and field.description.has_requests and \
                     field.description.requirement.check(
-                    text_preprocessing_result, user, params
-            ):
+                        text_preprocessing_result, user, params
+                    ):
                 return field
 
     def get_fields_data(self, form, form_key):
@@ -173,9 +173,12 @@ class FormFillingScenario(BaseScenario):
         user.preprocessing_messages_for_scenarios.add(text_preprocessing_result)
 
         data_extracted = self._extract_data(form, text_preprocessing_result, user, params)
-        log("Extracted data={}".format(data_extracted), user, self._log_params())
+        logging_params = {"data_extracted_str": str(data_extracted)}
+        logging_params.update(self._log_params())
+        log("Extracted data=%(data_extracted_str)s", user, logging_params)
 
-        validation_error_msg = self._validate_extracted_data(user, text_preprocessing_result, form, data_extracted, params)
+        validation_error_msg = self._validate_extracted_data(user, text_preprocessing_result, form, data_extracted,
+                                                             params)
         if validation_error_msg:
             reply_messages = validation_error_msg
         else:

--- a/scenarios/scenario_models/field/composite_fillers.py
+++ b/scenarios/scenario_models/field/composite_fillers.py
@@ -22,9 +22,9 @@ class RequirementFiller(RequirementAction):
         return self._item
 
     def on_extract_error(self, text_preprocessing_result, user, params=None):
-        log("exc_handler: RequirementFiller failed to extract. Return None. MESSAGE: {}.".format(
-            user.message.masked_value),
-            user, {log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE}, level="ERROR", exc_info=True)
+        log("exc_handler: RequirementFiller failed to extract. Return None. MESSAGE: %(masked_message)s.",
+            user, {log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE, "masked_message": user.message.masked_value},
+            level="ERROR", exc_info=True)
         return None
 
     @exc_handler(on_error_obj_method_name="on_extract_error")
@@ -38,9 +38,9 @@ class ChoiceFiller(ChoiceAction):
     FIELD_ELSE_KEY = "else_filler"
 
     def on_extract_error(self, text_preprocessing_result, user, params=None):
-        log("exc_handler: ChoiceFiller failed to extract. Return None. MESSAGE: {}.".format(user.message.masked_value),
-            user,
-            {log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE}, level="ERROR", exc_info=True)
+        log("exc_handler: ChoiceFiller failed to extract. Return None. MESSAGE: %(masked_message)s.",
+            user, {log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE, "masked_message": user.message.masked_value},
+            level="ERROR", exc_info=True)
         return None
 
     @exc_handler(on_error_obj_method_name="on_extract_error")
@@ -54,9 +54,9 @@ class ElseFiller(ElseAction):
     FIELD_ELSE_KEY = "else_filler"
 
     def on_extract_error(self, text_preprocessing_result, user, params=None):
-        log("exc_handler: ElseFiller failed to extract. Return None. MESSAGE: {}.".format(user.message.masked_value),
-            user,
-            {log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE}, level="ERROR", exc_info=True)
+        log("exc_handler: ElseFiller failed to extract. Return None. MESSAGE: %(masked_message)s.",
+            user, {log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE, "masked_message": user.message.masked_value},
+            level="ERROR", exc_info=True)
         return None
 
     @exc_handler(on_error_obj_method_name="on_extract_error")

--- a/scenarios/scenario_models/field/field_filler_description.py
+++ b/scenarios/scenario_models/field/field_filler_description.py
@@ -48,8 +48,9 @@ class FieldFillerDescription:
         return None
 
     def on_extract_error(self, text_preprocessing_result, user, params=None):
-        log("exc_handler: Filler failed to extract. Return None. MESSAGE: {}.".format(user.message.masked_value), user,
-            {log_const.KEY_NAME: core_log_const.HANDLED_EXCEPTION_VALUE}, level="ERROR", exc_info=True)
+        log("exc_handler: Filler failed to extract. Return None. MESSAGE: %(masked_message)s.", user,
+            {log_const.KEY_NAME: core_log_const.HANDLED_EXCEPTION_VALUE, "masked_message": user.message.masked_value},
+            level="ERROR", exc_info=True)
         return None
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,

--- a/smart_kit/handlers/handle_close_app.py
+++ b/smart_kit/handlers/handle_close_app.py
@@ -15,8 +15,8 @@ class HandlerCloseApp(HandlerBase):
         super().run(payload, user)
         text_preprocessing_result = TextPreprocessingResult(payload.get("message", {}))
         params = {
-            log_const.KEY_NAME: "HandlerCloseApp"
+            log_const.KEY_NAME: "HandlerCloseApp",
+            "tpr_str": str(text_preprocessing_result.raw)
         }
         self._clear_current_scenario.run(user, text_preprocessing_result)
-        log("HandlerCloseApp with text preprocessing result: '{}'".format(text_preprocessing_result.raw),
-                      user, params)
+        log("HandlerCloseApp with text preprocessing result: '%(tpr_str)s'", user, params)

--- a/smart_kit/handlers/handle_close_app.py
+++ b/smart_kit/handlers/handle_close_app.py
@@ -19,4 +19,4 @@ class HandlerCloseApp(HandlerBase):
             "tpr_str": str(text_preprocessing_result.raw)
         }
         self._clear_current_scenario.run(user, text_preprocessing_result)
-        log("HandlerCloseApp with text preprocessing result: '%(tpr_str)s'", user, params)
+        log("HandlerCloseApp with text preprocessing result", user, params)

--- a/smart_kit/handlers/handler_text.py
+++ b/smart_kit/handlers/handler_text.py
@@ -23,7 +23,7 @@ class HandlerText(HandlerBase):
         super().run(payload, user)
         text_preprocessing_result = TextPreprocessingResult(payload.get("message", {}))
 
-        log("text preprocessing result: '%(tpr_str)s'", user,
+        log("text preprocessing result", user,
             {log_const.KEY_NAME: log_const.NORMALIZED_TEXT_VALUE, "tpr_str": str(text_preprocessing_result.raw)})
 
         answer = self._handle_base(text_preprocessing_result, user)

--- a/smart_kit/handlers/handler_text.py
+++ b/smart_kit/handlers/handler_text.py
@@ -23,8 +23,8 @@ class HandlerText(HandlerBase):
         super().run(payload, user)
         text_preprocessing_result = TextPreprocessingResult(payload.get("message", {}))
 
-        log("text preprocessing result: '{}'".format(str(text_preprocessing_result.raw)), user,
-                      {log_const.KEY_NAME: log_const.NORMALIZED_TEXT_VALUE})
+        log("text preprocessing result: '%(tpr_str)s'", user,
+            {log_const.KEY_NAME: log_const.NORMALIZED_TEXT_VALUE, "tpr_str": str(text_preprocessing_result.raw)})
 
         answer = self._handle_base(text_preprocessing_result, user)
         return answer

--- a/smart_kit/models/smartapp_model.py
+++ b/smart_kit/models/smartapp_model.py
@@ -70,10 +70,10 @@ class SmartAppModel:
         user.do_not_save = True
         smart_kit_metrics.counter_exception(self.app_name)
         params = {log_const.KEY_NAME: log_const.DIALOG_ERROR_VALUE,
-                  "message_id": user.message.incremental_id}
+                  "message_id": user.message.incremental_id,
+                  "masked_message": user.message.masked_value}
 
-        log("exc_handler: Failed to process message. Exception occurred. Fail in MESSAGE: {}".format(
-            user.message.masked_value),
+        log("exc_handler: Failed to process message. Exception occurred. Fail in MESSAGE: %(masked_message)s",
             user, params, level="ERROR", exc_info=True)
 
         callback_action_params = get_callback_action_params(user)

--- a/smart_kit/start_points/main_loop_async_http.py
+++ b/smart_kit/start_points/main_loop_async_http.py
@@ -129,8 +129,8 @@ class AIOHttpMainLoop(BaseHttpMainLoop):
 
     async def process_message(self, message: SmartAppFromMessage, *args, **kwargs):
         stats = ""
-        log("INCOMING DATA: {}".format(message.masked_value),
-            params={log_const.KEY_NAME: "incoming_policy_message"})
+        log("INCOMING DATA: %(masked_message)s",
+            params={log_const.KEY_NAME: "incoming_policy_message", "masked_message": message.masked_value})
         db_uid = message.db_uid
 
         with StatsTimer() as load_timer:

--- a/smart_kit/start_points/main_loop_http.py
+++ b/smart_kit/start_points/main_loop_http.py
@@ -60,8 +60,9 @@ class BaseHttpMainLoop(BaseMainLoop):
 
     def process_message(self, message: SmartAppFromMessage, *args, **kwargs):
         stats = ""
-        log("INCOMING DATA: {}".format(message.masked_value),
-            params={log_const.KEY_NAME: "incoming_policy_message"})
+        log("INCOMING DATA: %(masked_message)s",
+            params={log_const.KEY_NAME: "incoming_policy_message",
+                    "masked_message": message.masked_value})
         db_uid = message.db_uid
 
         with StatsTimer() as load_timer:


### PR DESCRIPTION
Логгер падет с exception в ситуации, когда одновременно:

- функция behaviour_log вызывается с параметрами (parameters)
- В передаваемой строке есть форматирование "{}".format(..).
- В параметре для форматирования есть символ %

Ошибка наблюдается в этом месте в филлерах:
`log("Extracted data={}".format(data_extracted), user, self._log_params())
`
например, на тексте, который содержит "скидкой 50%, и какая берётся комиссия"

Лечится передачей переменных .format в словарь parameters и  **НЕ**использованием .format
Через поиск по regex "log.*\\.format" нашел проблемные вызовы. Изменил сигнатуру, где в параметрах могло попасть пользовательское сообщение. 