### PR TITLE
Rework of masking function

### DIFF
--- a/core/utils/masking_message.py
+++ b/core/utils/masking_message.py
@@ -9,6 +9,8 @@ card_regular = re.compile(r"(?:(\d{18})|(\d{16})|(?:\d{4} ){3}(\d{4})(\s?\d{2})?
 
 
 class Counter(object):
+    # Класс счетчик для маскировки структуры, items - кол-во простых элементов, collections - коллекций
+    # max_depth - максимальная глубина
     def __init__(self):
         self.items = 0
         self.collections = 0
@@ -40,22 +42,27 @@ def check_value_is_collection(value):
 
 
 def masking(data: Union[MutableMapping, Iterable], masking_fields: Optional[Union[MutableMapping, Iterable]] = None,
-            deep_level: int = 2, mask_available_depth: int = -1, masking_on: bool = False,
-            card_masking_on: bool = False):
-    """
-    :param data: коллекция для маскирования приватных данных
-    :param masking_fields: поля для обязательной маскировки независимо от уровня
-    :param deep_level: глубина сохранения структуры маскируемого поля
-    :param mask_available_depth: глубина глубокой маскировки полей без сохранения структуры (см ниже)
-    :param masking_on: флаг о включенной выше маскировке, в случае маскировки вложенных полей
-    :param card_masking_on: флаг о вкюченном маскировании карт
-    """
+            depth_level: int = 2, mask_available_depth: int = -1):
     if masking_fields is None:
         masking_fields = DEFAULT_MASKING_FIELDS
 
     if isinstance(masking_fields, Iterable):
-        masking_fields = {key: deep_level for key in masking_fields}
+        masking_fields = {key: depth_level for key in masking_fields}
 
+    _masking(data, masking_fields, depth_level, mask_available_depth, masking_on=False, card_masking_on=False)
+
+
+def _masking(data: Union[MutableMapping, Iterable], masking_fields: Union[MutableMapping, Iterable],
+             depth_level: int = 2, mask_available_depth: int = -1, masking_on: bool = False,
+             card_masking_on: bool = False):
+    """
+    :param data: коллекция для маскирования приватных данных
+    :param masking_fields: поля для обязательной маскировки независимо от уровня
+    :param depth_level: глубина сохранения структуры маскируемого поля
+    :param mask_available_depth: глубина глубокой маскировки полей без сохранения структуры (см ниже)
+    :param masking_on: флаг о включенной выше маскировке, в случае маскировки вложенных полей
+    :param card_masking_on: флаг о вкюченном маскировании карт
+    """
     # тут в зависимости от листа или словаря создаем итератор
     if isinstance(data, MutableMapping):
         key_gen = data.items()
@@ -67,39 +74,35 @@ def masking(data: Union[MutableMapping, Iterable], masking_fields: Optional[Unio
         if masking_on or key in masking_fields:
             if value_is_collection:
                 # если глубина не превышена, идем внутрь с включенным флагом и уменьшаем глубину
-                if masking_on and deep_level > 0:
-                    masking(data[key], masking_fields, deep_level - 1, mask_available_depth, masking_on=True)
+                if masking_on and depth_level > 0:
+                    _masking(data[key], masking_fields, depth_level - 1, mask_available_depth, masking_on=True)
                 elif key in masking_fields and masking_fields[key] > 0:
-                    masking(data[key], masking_fields, masking_fields[key] - 1, mask_available_depth, masking_on=True)
+                    _masking(data[key], masking_fields, masking_fields[key] - 1, mask_available_depth, masking_on=True)
                 else:
-                    counter = deep_mask(data[key], depth=1, available_depth=mask_available_depth)
+                    counter = structure_mask(data[key], depth=1, available_depth=mask_available_depth)
                     data[key] = f'*items-{counter.items}*collections-{counter.collections}*maxdepth-{counter.max_depth}*'
             elif data[key] is not None:  # в случае простого элемента. маскируем как ***
                 data[key] = '***'
         elif card_masking_on and isinstance(data[key], str):  # проверка на реквизиты карты
             data[key] = card_regular.sub(card_sub_func, data[key])
         elif key in CARD_MASKING_FIELDS:  # проверка на реквизиты карты
-            masking(data[key], masking_fields, deep_level, mask_available_depth, masking_on=False,
-                    card_masking_on=True)
+            _masking(data[key], masking_fields, depth_level, mask_available_depth, masking_on=False,
+                     card_masking_on=True)
         elif value_is_collection:
             # если маскировка не нужна уходим глубже без включенного флага
-            masking(data[key], masking_fields, deep_level, mask_available_depth,
-                    masking_on=False, card_masking_on=card_masking_on)
+            _masking(data[key], masking_fields, depth_level, mask_available_depth,
+                     masking_on=False, card_masking_on=card_masking_on)
 
 
-def deep_mask(data: Union[MutableMapping, Iterable], depth: int, available_depth: int = -1,
-              counter: Optional[Counter] = None):
+def structure_mask(data: Union[MutableMapping, Iterable], depth: int, available_depth: int = -1,
+                   counter: Optional[Counter] = None):
     """
-    Функция глубокой максировки для вложенной структуры, tuple из 3х чисел:
-     1 - количество простых элементов,
-     2 - количество коллекций,
-     3 - максимальную глубину
-
-    :param counter: объект счетчик
-    :param available_depth: максимальная глубина прохода, при -1 глубина не ограничена
+    Функция максировки для сложной структуры
     :param data: структура маскируемая без сохранения структуры
     :param depth: текущая глубина вложенности
-
+    :param available_depth: максимальная глубина прохода, при -1 глубина не ограничена
+    :param counter: объект счетчик
+    :return: counter с подсчитанными элементами
     """
     # в зависимости от листа или словаря создаем итератор
     if isinstance(data, MutableMapping):
@@ -115,7 +118,7 @@ def deep_mask(data: Union[MutableMapping, Iterable], depth: int, available_depth
             counter.collections += 1
             # если встречаем коллекцию и глубина не превышена идем внутрь
             if depth < available_depth or available_depth == -1:
-                deep_mask(data[key], depth + 1, available_depth, counter)
+                structure_mask(data[key], depth + 1, available_depth, counter)
         else:
             # если элемент простой крутим счетчик простых элементов
             counter.items += 1

--- a/core/utils/masking_message.py
+++ b/core/utils/masking_message.py
@@ -8,6 +8,13 @@ CARD_MASKING_FIELDS = ["message", "debug_info", "normalizedMessage", "incoming_t
 card_regular = re.compile(r"(?:(\d{18})|(\d{16})|(?:\d{4} ){3}(\d{4})(\s?\d{2})?)")
 
 
+class Counter(object):
+    def __init__(self):
+        self.items = 0
+        self.collections = 0
+        self.max_depth = 1
+
+
 def luhn_checksum(card_number: str) -> bool:
     digits = [int(d) for d in card_number]
     odd_digits = digits[-1::-2]
@@ -28,33 +35,26 @@ def card_sub_func(x: Match[str]) -> str:
     return mask + digs + (last_char * is_last_not_digit)
 
 
-def regex_masking(record: Union[Mapping, str, Iterable], regex: Pattern[str], func: Callable[[Match[str]], str]) \
-        -> Union[Mapping, str, Iterable]:
-    if isinstance(record, Mapping):
-        return {k: regex_masking(v, regex, func) for k, v in record.items()}
-    elif isinstance(record, str):
-        return regex.sub(func, record)
-    elif isinstance(record, Iterable):
-        return [regex_masking(i, regex, func) for i in record]
-    else:
-        return record
-
-
 def check_value_is_collection(value):
     return isinstance(value, MutableMapping) or isinstance(value, Iterable) and not isinstance(value, str)
 
 
-def masking(data: Union[MutableMapping, Iterable], masking_fields: Optional[Iterable] = None,
-            deep_level: int = 2, mask_available_depth: int = -1, masking_on: bool = False):
+def masking(data: Union[MutableMapping, Iterable], masking_fields: Optional[Union[MutableMapping, Iterable]] = None,
+            deep_level: int = 2, mask_available_depth: int = -1, masking_on: bool = False,
+            card_masking_on: bool = False):
     """
     :param data: коллекция для маскирования приватных данных
     :param masking_fields: поля для обязательной маскировки независимо от уровня
     :param deep_level: глубина сохранения структуры маскируемого поля
     :param mask_available_depth: глубина глубокой маскировки полей без сохранения структуры (см ниже)
     :param masking_on: флаг о включенной выше маскировке, в случае маскировки вложенных полей
+    :param card_masking_on: флаг о вкюченном маскировании карт
     """
     if masking_fields is None:
         masking_fields = DEFAULT_MASKING_FIELDS
+
+    if isinstance(masking_fields, Iterable):
+        masking_fields = {key: deep_level for key in masking_fields}
 
     # тут в зависимости от листа или словаря создаем итератор
     if isinstance(data, MutableMapping):
@@ -64,58 +64,61 @@ def masking(data: Union[MutableMapping, Iterable], masking_fields: Optional[Iter
 
     for key, _ in key_gen:
         value_is_collection = check_value_is_collection(data[key])
-        if key in masking_fields or masking_on:
+        if masking_on or key in masking_fields:
             if value_is_collection:
-                if deep_level > 0:
-                    # если глубина не превышена, идем внутрь с включенным флагом и уменьшаем глубину
+                # если глубина не превышена, идем внутрь с включенным флагом и уменьшаем глубину
+                if masking_on and deep_level > 0:
                     masking(data[key], masking_fields, deep_level - 1, masking_on=True)
+                elif key in masking_fields and masking_fields[key] > 0:
+                    masking(data[key], masking_fields, masking_fields[key], masking_on=True)
                 else:
-                    # если глубина превышена маскируем составной маской
-                    item_counter, collection_counter, max_depth = deep_mask(
-                        data[key], depth=1, available_depth=mask_available_depth)
-                    data[key] = f'*items-{item_counter}*collections-{collection_counter}*maxdepth-{max_depth}*'
+                    counter = deep_mask(data[key], depth=1, available_depth=mask_available_depth)
+                    data[
+                        key] = f'*items-{counter.items}*collections-{counter.collections}*maxdepth-{counter.max_depth}*'
             elif data[key] is not None:  # в случае простого элемента. маскируем как ***
                 data[key] = '***'
+        elif card_masking_on and isinstance(data[key], str):  # проверка на реквизиты карты
+            data[key] = card_regular.sub(card_sub_func, data[key])
         elif key in CARD_MASKING_FIELDS:  # проверка на реквизиты карты
-            data[key] = regex_masking(data[key], card_regular, card_sub_func)
+            masking(data[key], masking_fields, deep_level, masking_on=masking_on, card_masking_on=True)
         elif value_is_collection:
             # если маскировка не нужна уходим глубже без включенного флага
-            masking(data[key], masking_fields, deep_level, masking_on=False)
+            masking(data[key], masking_fields, deep_level, masking_on=False, card_masking_on=card_masking_on)
 
 
-def deep_mask(data: Union[MutableMapping, Iterable], depth: int, available_depth: int = -1):
+def deep_mask(data: Union[MutableMapping, Iterable], depth: int, available_depth: int = -1,
+              counter: Optional[Counter] = None):
     """
     Функция глубокой максировки для вложенной структуры, tuple из 3х чисел:
      1 - количество простых элементов,
      2 - количество коллекций,
      3 - максимальную глубину
 
+    :param counter: объект счетчик
+    :param available_depth: максимальная глубина прохода, при -1 глубина не ограничена
     :param data: структура маскируемая без сохранения структуры
     :param depth: текущая глубина вложенности
-    :param available_depth: максимальная допустимая глубина, -1 неограниченная
-    """
-    item_counter = 0
-    collection_counter = 0
-    max_depth = 0
 
+    """
     # в зависимости от листа или словаря создаем итератор
     if isinstance(data, MutableMapping):
         key_gen = data.items()
     else:
         key_gen = enumerate(data)
 
+    if counter is None:
+        counter = Counter()
+
     for key, _ in key_gen:
         if check_value_is_collection(data[key]):
-            collection_counter += 1
+            counter.collections += 1
             # если встречаем коллекцию и глубина не превышена идем внутрь
-            if available_depth > depth or available_depth == -1:
-                items, collections, collection_depth = deep_mask(data[key], item_counter, collection_counter)
-                item_counter += items
-                collection_counter += collections
-                if collection_depth > max_depth:
-                    max_depth = collection_depth
+            if depth < available_depth or depth == -1:
+                deep_mask(data[key], depth + 1, available_depth, counter)
         else:
             # если элемент простой крутим счетчик простых элементов
-            item_counter += 1
+            counter.items += 1
+            if depth > counter.max_depth:
+                counter.max_depth = depth
 
-    return item_counter, collection_counter, max_depth + 1
+    return counter

--- a/core/utils/masking_message.py
+++ b/core/utils/masking_message.py
@@ -43,6 +43,12 @@ def check_value_is_collection(value):
 
 def masking(data: Union[MutableMapping, Iterable], masking_fields: Optional[Union[MutableMapping, Iterable]] = None,
             depth_level: int = 2, mask_available_depth: int = -1):
+    """
+    :param data: коллекция для маскирования приватных данных
+    :param masking_fields: поля для обязательной маскировки независимо от уровня
+    :param depth_level: глубина сохранения структуры маскируемого поля
+    :param mask_available_depth: глубина глубокой маскировки полей без сохранения структуры (см ниже)
+    """
     if masking_fields is None:
         masking_fields = DEFAULT_MASKING_FIELDS
 
@@ -55,14 +61,7 @@ def masking(data: Union[MutableMapping, Iterable], masking_fields: Optional[Unio
 def _masking(data: Union[MutableMapping, Iterable], masking_fields: Union[MutableMapping, Iterable],
              depth_level: int = 2, mask_available_depth: int = -1, masking_on: bool = False,
              card_masking_on: bool = False):
-    """
-    :param data: коллекция для маскирования приватных данных
-    :param masking_fields: поля для обязательной маскировки независимо от уровня
-    :param depth_level: глубина сохранения структуры маскируемого поля
-    :param mask_available_depth: глубина глубокой маскировки полей без сохранения структуры (см ниже)
-    :param masking_on: флаг о включенной выше маскировке, в случае маскировки вложенных полей
-    :param card_masking_on: флаг о вкюченном маскировании карт
-    """
+
     # тут в зависимости от листа или словаря создаем итератор
     if isinstance(data, MutableMapping):
         key_gen = data.items()

--- a/tests/core_tests/masking_test/masking_test.py
+++ b/tests/core_tests/masking_test/masking_test.py
@@ -95,7 +95,7 @@ class MaskingTest(TestCase):
         message = SmartAppFromMessage(value=json_input_msg, headers=[])
 
         masked_message = json.loads(message.masked_value)
-        result_message = input_msg = {
+        result_message = {
             "messageId": 2,
             "uuid": {"userChannel": "B2C", "epkId": "***", "sub": "sub"},
             "payload": {

--- a/tests/core_tests/masking_test/masking_test.py
+++ b/tests/core_tests/masking_test/masking_test.py
@@ -111,3 +111,89 @@ class MaskingTest(TestCase):
         }
 
         self.assertEqual(masked_message, result_message)
+
+    def test_6(self):
+        input_msg = {
+            "messageId": 2,
+            "uuid": {"userChannel": "B2C", "epkId": ["1234567", "secret", {"key1": 123, "key2": 456}], "sub": "sub"},
+            "payload": {
+                "message": {
+                    "original_text": "Номер карты1234567890123456 вот"
+                },
+                "profileId": [123, 456]
+            },
+            "messageName": "MESSAGE_TO_SKILL",
+            "data": {
+                "refresh_token": [123, 456, {"key": {"inner_dict": ["inner_list", 123, 456]}}]
+            },
+            "here_no_cards":{"no_card":"1234567890123456", "data" : {"token": 123}}
+        }
+
+        json_input_msg = json.dumps(input_msg, ensure_ascii=False)
+        message = SmartAppFromMessage(value=json_input_msg, headers=[])
+
+        masked_message = json.loads(message.masked_value)
+        result_message = {
+            "messageId": 2,
+            "uuid": {"userChannel": "B2C", "epkId": ['***', '***', {'key1': '***', 'key2': '***'}], "sub": "sub"},
+            "payload": {
+                "message": {
+                    "original_text": "Номер карты************3456 вот"
+                },
+                "profileId": ['***', '***']
+            },
+            "messageName": "MESSAGE_TO_SKILL",
+            "data": {
+                "refresh_token": ['***', '***', {'key': '*items-3*collections-1*maxdepth-2*'}]
+            },
+            'here_no_cards': {'no_card': '1234567890123456', 'data': {'token': '***'}
+            }
+        }
+
+        self.assertEqual(masked_message, result_message)
+
+    def test_7(self):
+        input_msg = {
+            "messageId": 2,
+            "uuid": {"userChannel": "B2C", "epkId": ["1234567890123456", "secret", {"key1": 123, "key2": 456}], "sub": "sub"},
+            "payload": {
+                "message": {
+                    "original_text": "Номер карты1234567890123456 вот",
+                    "token": 123
+                },
+                "profileId": [123, 456]
+            },
+            "messageName": "MESSAGE_TO_SKILL",
+            "data": {
+                "refresh_token": [123, 456, {"key": {"inner_dict": ["inner_list", 123, 456]}}]
+            },
+            "here_no_cards": {"no_card": "1234567890123456", "data": {"token": 123}},
+            "message": ["1234567890123456", {"token": [123, 456, ["item1", "item2", ["inner list"]]]},
+                        {"card_here":["1234567890123456", "card1234567890123456here"]}]
+        }
+
+        json_input_msg = json.dumps(input_msg, ensure_ascii=False)
+        message = SmartAppFromMessage(value=json_input_msg, headers=[])
+
+        masked_message = json.loads(message.masked_value)
+        result_message = {
+            "messageId": 2,
+            "uuid": {"userChannel": "B2C", "epkId": ['***', '***', {'key1': '***', 'key2': '***'}], "sub": "sub"},
+            "payload": {
+                "message": {
+                    "original_text": "Номер карты************3456 вот",
+                    'token': '***'
+                },
+                "profileId": ['***', '***']
+            },
+            "messageName": "MESSAGE_TO_SKILL",
+            "data": {
+                "refresh_token": ['***', '***', {'key': '*items-3*collections-1*maxdepth-2*'}]
+            },
+            'here_no_cards': {'no_card': '1234567890123456', 'data': {'token': '***'}},
+            'message': ['************3456',
+                        {'token': ['***', '***', ['***', '***', '*items-1*collections-0*maxdepth-1*']]},
+                        {'card_here': ['************3456', 'card************3456here']}]
+        }
+
+        self.assertEqual(masked_message, result_message)


### PR DESCRIPTION
Доработки с маскированием:
- Отедельную функцию маскирование карты перенесли в основную функцию маскировки
- Поля CARD_MASKING_FIELDS теперь могут быть заданы словарем с глубиной маскирования, например `{'bank_token': 2}`, если передаются как раньше списком - то преобраются в словарь, где каждому полю статся дефолтная глубина из deep_level
- Рефакторинг счетчика функции `deep_mask` - вместо параметров теперь используется объект счетчик для читабельности