### PR TITLE
refactoring tests for masking

### DIFF
--- a/tests/core_tests/masking_test/masking_test.py
+++ b/tests/core_tests/masking_test/masking_test.py
@@ -94,3 +94,18 @@ class MaskingTest(TestCase):
         masking(input_, masking_fields, depth_level)
         self.assertEqual(input_, expected)
 
+    def test_int_card(self):
+        input_msg = {'message': 1234567890123456}
+        expected = {'message': '************3456'}
+        masking(input_msg)
+        self.assertEqual(input_msg, expected)
+
+        input_msg = {'message': {'card':1234567890123456}}
+        expected = {'message': {'card':'************3456'}}
+        masking(input_msg)
+        self.assertEqual(input_msg, expected)
+
+        input_msg = {'message': 1234}
+        expected = {'message': 1234}
+        masking(input_msg)
+        self.assertEqual(input_msg, expected)

--- a/tests/core_tests/masking_test/masking_test.py
+++ b/tests/core_tests/masking_test/masking_test.py
@@ -197,3 +197,28 @@ class MaskingTest(TestCase):
         }
 
         self.assertEqual(masked_message, result_message)
+
+    def test_8(self):
+        input_msg = {
+            "messageId": 2,
+            "uuid": {"userChannel": "B2C", "epkId": ["1234567890123456", "secret", {"key1": 123, "key2": 456}], "sub": "sub"},
+            "payload": {
+                "message": "Номер карты1234567890123456 вот",
+                "profileId": [123, 456]
+            }
+        }
+
+        json_input_msg = json.dumps(input_msg, ensure_ascii=False)
+        message = SmartAppFromMessage(value=json_input_msg, headers=[])
+
+        masked_message = json.loads(message.masked_value)
+        result_message = {
+            "messageId": 2,
+            "uuid": {"userChannel": "B2C", "epkId": ['***', '***', {'key1': '***', 'key2': '***'}], "sub": "sub"},
+            "payload": {
+                "message": "Номер карты************3456 вот",
+                "profileId": ['***', '***']
+            }
+        }
+
+        self.assertEqual(masked_message, result_message)

--- a/tests/core_tests/masking_test/masking_test.py
+++ b/tests/core_tests/masking_test/masking_test.py
@@ -57,55 +57,56 @@ class MaskingTest(TestCase):
         self.assertEqual(input_msg, expected)
 
     def test_masking(self):
-        input_message = {"refresh_token": '123456'}
-        expected = {"refresh_token": '***'}
-        masking(input_message)
+        masking_fields = {'spec_token': 2}
+        input_message = {"spec_token": '123456'}
+        expected = {"spec_token": '***'}
+        masking(input_message, masking_fields)
         self.assertEqual(input_message, expected)
 
         # все простые типы маскируются как '***'
-        input_message = {"refresh_token": {'int': 123, 'str': 'str', 'bool': True}}
-        expected = {"refresh_token": {'int': '***', 'str': '***', 'bool': '***'}}
-        masking(input_message)
+        input_message = {"spec_token": {'int': 123, 'str': 'str', 'bool': True}}
+        expected = {"spec_token": {'int': '***', 'str': '***', 'bool': '***'}}
+        masking(input_message, masking_fields)
         self.assertEqual(input_message, expected)
 
         # если маскируемое поле окажется внутри банковского поля - то оно маскируется с заданной вложеностью
-        input_msg = {'message': {'token': ['12', ['12', {'data': {'key': '12'}}]]}}
-        expected = {'message': {'token': ['***', ['***', '*items-1*collections-1*maxdepth-2*']]}}
-        masking(input_msg, masking_fields={'token': 2})
+        input_msg = {'message': {'spec_token': ['12', ['12', {'data': {'key': '12'}}]]}}
+        expected = {'message': {'spec_token': ['***', ['***', '*items-1*collections-1*maxdepth-2*']]}}
+        masking(input_msg, masking_fields)
         self.assertEqual(input_msg, expected)
 
     def test_depth(self):
         # вложенность любой длины не маскируется пока не встретим ключ для маскировки
-        masking_fields = ['token']
+        masking_fields = ['spec_token']
         depth_level = 0
-        input_msg = {'a': {'b': {'c': 1, 'token': '123456'}}}
-        expected = {'a': {'b': {'c': 1, 'token': '***'}}}
+        input_msg = {'a': {'b': {'c': 1, 'spec_token': '123456'}}}
+        expected = {'a': {'b': {'c': 1, 'spec_token': '***'}}}
         masking(input_msg, masking_fields, depth_level)
         self.assertEqual(input_msg, expected)
 
         # проверка вложенной маскировки
-        input_msg = {'token': [12, 12, {'key': [12, 12]}]}
+        input_msg = {'spec_token': [12, 12, {'key': [12, 12]}]}
 
         depth_level = 3
-        expected = {'token': ['***', '***', {'key': ['***', '***']}]}
+        expected = {'spec_token': ['***', '***', {'key': ['***', '***']}]}
         input_ = copy.deepcopy(input_msg)
         masking(input_, masking_fields, depth_level)
-        self.assertEqual(input_, expected)
+        self.assertEqual(expected, input_)
 
         depth_level = 2
-        expected = {'token': ['***', '***', {'key': '*items-2*collections-0*maxdepth-1*'}]}
+        expected = {'spec_token': ['***', '***', {'key': '*items-2*collections-0*maxdepth-1*'}]}
         input_ = copy.deepcopy(input_msg)
         masking(input_, masking_fields, depth_level)
         self.assertEqual(input_, expected)
 
         depth_level = 1
-        expected = {'token': ['***', '***', '*items-2*collections-1*maxdepth-2*']}
+        expected = {'spec_token': ['***', '***', '*items-2*collections-1*maxdepth-2*']}
         input_ = copy.deepcopy(input_msg)
         masking(input_, masking_fields, depth_level)
         self.assertEqual(input_, expected)
 
         depth_level = 0
-        expected = {'token': '*items-4*collections-2*maxdepth-3*'}
+        expected = {'spec_token': '*items-4*collections-2*maxdepth-3*'}
         input_ = copy.deepcopy(input_msg)
         masking(input_, masking_fields, depth_level)
         self.assertEqual(input_, expected)

--- a/tests/core_tests/masking_test/masking_test.py
+++ b/tests/core_tests/masking_test/masking_test.py
@@ -40,6 +40,22 @@ class MaskingTest(TestCase):
         masking(input_msg)
         self.assertEqual(input_msg, expected)
 
+        # проверки на целочисленный тип значений
+        input_msg = {'message': 1234567890123456}
+        expected = {'message': '************3456'}
+        masking(input_msg)
+        self.assertEqual(input_msg, expected)
+
+        input_msg = {'message': {'card': 1234567890123456}}
+        expected = {'message': {'card': '************3456'}}
+        masking(input_msg)
+        self.assertEqual(input_msg, expected)
+
+        input_msg = {'message': 1234}
+        expected = {'message': 1234}
+        masking(input_msg)
+        self.assertEqual(input_msg, expected)
+
     def test_masking(self):
         input_message = {"refresh_token": '123456'}
         expected = {"refresh_token": '***'}
@@ -93,19 +109,3 @@ class MaskingTest(TestCase):
         input_ = copy.deepcopy(input_msg)
         masking(input_, masking_fields, depth_level)
         self.assertEqual(input_, expected)
-
-    def test_int_card(self):
-        input_msg = {'message': 1234567890123456}
-        expected = {'message': '************3456'}
-        masking(input_msg)
-        self.assertEqual(input_msg, expected)
-
-        input_msg = {'message': {'card':1234567890123456}}
-        expected = {'message': {'card':'************3456'}}
-        masking(input_msg)
-        self.assertEqual(input_msg, expected)
-
-        input_msg = {'message': 1234}
-        expected = {'message': 1234}
-        masking(input_msg)
-        self.assertEqual(input_msg, expected)

--- a/tests/core_tests/masking_test/masking_test.py
+++ b/tests/core_tests/masking_test/masking_test.py
@@ -10,70 +10,70 @@ class MaskingTest(TestCase):
         input_msg = {"message": "Слово до 1234567890123456"}
         expected = {"message": "Слово до ************3456"}
         masking(input_msg)
-        self.assertEqual(input_msg, expected)
+        self.assertEqual(expected, input_msg)
 
         input_msg = {"message": "Слово до 1234567890123456 и после"}
         expected = {"message": "Слово до ************3456 и после"}
         masking(input_msg)
-        self.assertEqual(input_msg, expected)
+        self.assertEqual(expected, input_msg)
 
         input_msg = {"message": "Склеено1234567890123456"}
         expected = {"message": "Склеено************3456"}
         masking(input_msg)
-        self.assertEqual(input_msg, expected)
+        self.assertEqual(expected, input_msg)
 
         # если это поле входит в банковские, но не проходит по регулярке - то не маскируем
         input_msg = {"message": "1234"}
         expected = {"message": "1234"}
         masking(input_msg)
-        self.assertEqual(input_msg, expected)
+        self.assertEqual(expected, input_msg)
 
         # маскировка так же применится к банковскому полю внутри коллекции
         input_msg = {'message': {'card': '1234567890123456'}}
         expected = {'message': {'card': '************3456'}}
         masking(input_msg, masking_fields=['token'])
-        self.assertEqual(input_msg, expected)
+        self.assertEqual(expected, input_msg)
 
         # если это не баковское поле - то не маскируем
         input_msg = {'here_no_cards': {'no_card': '1234567890123456'}}
         expected = {'here_no_cards': {'no_card': '1234567890123456'}}
         masking(input_msg)
-        self.assertEqual(input_msg, expected)
+        self.assertEqual(expected, input_msg)
 
         # проверки на целочисленный тип значений
         input_msg = {'message': 1234567890123456}
         expected = {'message': '************3456'}
         masking(input_msg)
-        self.assertEqual(input_msg, expected)
+        self.assertEqual(expected, input_msg)
 
         input_msg = {'message': {'card': 1234567890123456}}
         expected = {'message': {'card': '************3456'}}
         masking(input_msg)
-        self.assertEqual(input_msg, expected)
+        self.assertEqual(expected, input_msg)
 
         input_msg = {'message': 1234}
         expected = {'message': 1234}
         masking(input_msg)
-        self.assertEqual(input_msg, expected)
+        self.assertEqual(expected, input_msg)
 
     def test_masking(self):
         masking_fields = {'spec_token': 2}
-        input_message = {"spec_token": '123456'}
+        input_msg = {"spec_token": '123456'}
         expected = {"spec_token": '***'}
-        masking(input_message, masking_fields)
-        self.assertEqual(input_message, expected)
+        masking(input_msg, masking_fields)
+        self.assertEqual(expected, input_msg)
 
         # все простые типы маскируются как '***'
-        input_message = {"spec_token": {'int': 123, 'str': 'str', 'bool': True}}
+        input_msg = {"spec_token": {'int': 123, 'str': 'str', 'bool': True}}
         expected = {"spec_token": {'int': '***', 'str': '***', 'bool': '***'}}
-        masking(input_message, masking_fields)
-        self.assertEqual(input_message, expected)
+        masking(input_msg, masking_fields)
+        self.assertEqual(expected, input_msg)
 
         # если маскируемое поле окажется внутри банковского поля - то оно маскируется с заданной вложеностью
         input_msg = {'message': {'spec_token': ['12', ['12', {'data': {'key': '12'}}]]}}
         expected = {'message': {'spec_token': ['***', ['***', '*items-1*collections-1*maxdepth-2*']]}}
         masking(input_msg, masking_fields)
-        self.assertEqual(input_msg, expected)
+        self.assertEqual(expected, input_msg)
 
     def test_depth(self):
         # вложенность любой длины не маскируется пока не встретим ключ для маскировки
@@ -82,31 +82,31 @@ class MaskingTest(TestCase):
         input_msg = {'a': {'b': {'c': 1, 'spec_token': '123456'}}}
         expected = {'a': {'b': {'c': 1, 'spec_token': '***'}}}
         masking(input_msg, masking_fields, depth_level)
-        self.assertEqual(input_msg, expected)
+        self.assertEqual(expected, input_msg)
 
         # проверка вложенной маскировки
-        input_msg = {'spec_token': [12, 12, {'key': [12, 12]}]}
+        input_ = {'spec_token': [12, 12, {'key': [12, 12]}]}
 
         depth_level = 3
         expected = {'spec_token': ['***', '***', {'key': ['***', '***']}]}
-        input_ = copy.deepcopy(input_msg)
-        masking(input_, masking_fields, depth_level)
-        self.assertEqual(expected, input_)
+        input_msg = copy.deepcopy(input_)
+        masking(input_msg, masking_fields, depth_level)
+        self.assertEqual(expected, input_msg)
 
         depth_level = 2
         expected = {'spec_token': ['***', '***', {'key': '*items-2*collections-0*maxdepth-1*'}]}
-        input_ = copy.deepcopy(input_msg)
-        masking(input_, masking_fields, depth_level)
-        self.assertEqual(input_, expected)
+        input_msg = copy.deepcopy(input_)
+        masking(input_msg, masking_fields, depth_level)
+        self.assertEqual(expected, input_msg)
 
         depth_level = 1
         expected = {'spec_token': ['***', '***', '*items-2*collections-1*maxdepth-2*']}
-        input_ = copy.deepcopy(input_msg)
-        masking(input_, masking_fields, depth_level)
-        self.assertEqual(input_, expected)
+        input_msg = copy.deepcopy(input_)
+        masking(input_msg, masking_fields, depth_level)
+        self.assertEqual(expected, input_msg)
 
         depth_level = 0
         expected = {'spec_token': '*items-4*collections-2*maxdepth-3*'}
-        input_ = copy.deepcopy(input_msg)
-        masking(input_, masking_fields, depth_level)
-        self.assertEqual(input_, expected)
+        input_msg = copy.deepcopy(input_)
+        masking(input_msg, masking_fields, depth_level)
+        self.assertEqual(expected, input_msg)


### PR DESCRIPTION
Отрефакторили тесты, поделили на три основных: 
- тест на маскриование карт
- тест на маскирование остальных типов
- тест на глубину маскирования