### PR TITLE
refactored test_date_determining.py module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "timeout-decorator==0.4.1",
         "tqdm",
         "Twisted",
-        "freezegun",
+        "freezegun==1.1.0",
     ],
     classifiers=[
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         "timeout-decorator==0.4.1",
         "tqdm",
         "Twisted"
+        "freezegun",
     ],
     classifiers=[
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "tensorflow==2.6.0",
         "timeout-decorator==0.4.1",
         "tqdm",
-        "Twisted"
+        "Twisted",
         "freezegun",
     ],
     classifiers=[

--- a/tests/core_tests/test_utils/test_date_determining.py
+++ b/tests/core_tests/test_utils/test_date_determining.py
@@ -4,17 +4,18 @@
 
 from typing import Optional
 from datetime import datetime, timedelta
+from freezegun import freeze_time
 from core.utils.period_determiner import ERROR_VALUE
 from core.utils.period_determiner import UNRECOGNIZED_DATE_VALUE
 from core.utils.period_determiner import period_determiner
 from core.utils.period_determiner import extract_words_describing_period
 
 
-current_date: datetime = datetime.now()
-
-
+@freeze_time('2021-11-23')
 def test_period_determiner_1():
     # если используется форма "с месяца года по ныне"
+    current_date = datetime.now()
+
     words_to_process = [
         'с',
         'марта',
@@ -30,8 +31,11 @@ def test_period_determiner_1():
                               current_date.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_2():
     # если используется форма "за месяц год по сегодняшний день"
+    current_date = datetime.now()
+
     words_to_process = [
         'марта',
         '2019',
@@ -47,6 +51,7 @@ def test_period_determiner_2():
                               current_date.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_3():
     # если используется полная форма
     words_to_process = [
@@ -62,6 +67,7 @@ def test_period_determiner_3():
     assert result == ('01.03.2019', '15.06.2021')
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_4():
     # если дата начала больше даты окончания периода
     words_to_process = [
@@ -77,8 +83,11 @@ def test_period_determiner_4():
     assert result == (ERROR_VALUE, ERROR_VALUE)
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_5():
     # если используется форма "за несколько прошлых месяцев"
+    current_date = datetime.now()
+
     delta_month = 4
     words_to_process = [
         str(delta_month),
@@ -104,8 +113,11 @@ def test_period_determiner_5():
     )
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_6():
     # если используется форма "за несколько прошлых дня"
+    current_date = datetime.now()
+
     delta_day = 4
     words_to_process = [
         str(delta_day),
@@ -123,6 +135,7 @@ def test_period_determiner_6():
     )
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_7():
     # если переданы год и месяц
     words_to_process = [
@@ -133,6 +146,7 @@ def test_period_determiner_7():
     assert result == ('01.06.2013', '30.06.2013')
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_8():
     # если корректные даты переданы в формате dd.mm.yy и dd.mm.yyyy
     words_to_process = [
@@ -144,18 +158,24 @@ def test_period_determiner_8():
     assert result == ('28.01.2012', '12.03.2020')
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_9():
     # если даты передана в формате dd.mm
+    current_date = datetime.now()
+
     words_to_process = [
         '28.01'
     ]
     result = period_determiner(words_to_process)
-    assert result == ('28.01.{}'.format(current_date.year), '28.01.{}'
-                      .format(current_date.year))
+    assert result == ('28.01.{}'.format(current_date.year),
+                      '28.01.{}'.format(current_date.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_10():
     # если конкретный квартал ипользуется
+    current_date = datetime.now()
+
     words_to_process = [
         '3',
         'квартал',
@@ -165,8 +185,11 @@ def test_period_determiner_10():
     assert result == ('01.07.2020', '30.09.2020')
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_11():
     # если начиная с определенного квартала
+    current_date = datetime.now()
+
     words_to_process = [
         'с',
         '3',
@@ -180,6 +203,7 @@ def test_period_determiner_11():
                               current_date.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_12():
     # если одна из дат некорректная
     words_to_process = [
@@ -191,6 +215,7 @@ def test_period_determiner_12():
     assert result == (ERROR_VALUE, '12.03.2020')
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_13():
     # если передать две даты с союзом "и" между ними, то определится только последняя
     words_to_process = [
@@ -202,6 +227,7 @@ def test_period_determiner_13():
     assert result == ('12.03.2020', '12.03.2020')
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_14():
     # если на обработку попадут слова не связанные с периодами времени
     words_to_process = [
@@ -213,16 +239,20 @@ def test_period_determiner_14():
     assert result == (UNRECOGNIZED_DATE_VALUE, UNRECOGNIZED_DATE_VALUE)
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_15():
     # если используется только месяц
+    current_date = datetime.now()
+
     words_to_process = [
         'март'
     ]
     result = period_determiner(words_to_process)
-    assert result == ('01.03.{}'.format(current_date.year), '31.03.{}'
-                      .format(current_date.year))
+    assert result == ('01.03.{}'.format(current_date.year),
+                      '31.03.{}'.format(current_date.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_16():
     # если используется некорретная форма к примеру за март 28 2020 года
     words_to_process = [
@@ -235,6 +265,7 @@ def test_period_determiner_16():
     assert result == (ERROR_VALUE, ERROR_VALUE)
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_17():
     # если используется некорректная форма к примеру "за март 28",
     words_to_process = [
@@ -245,18 +276,22 @@ def test_period_determiner_17():
     assert result == (ERROR_VALUE, ERROR_VALUE)
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_18():
     # если используется корректная форма к примеру "за 28 марта",
     # то определится как 28 марта текущего года
+    current_date = datetime.now()
+
     words_to_process = [
         '28',
         'марта',
     ]
     result = period_determiner(words_to_process)
-    assert result == ('28.03.{}'.format(current_date.year), '28.03.{}'
-                      .format(current_date.year))
+    assert result == ('28.03.{}'.format(current_date.year),
+                      '28.03.{}'.format(current_date.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_19():
     # если используется корректная форма к примеру "за 28 марта",
     # то определится как 28 марта текущего года
@@ -269,9 +304,12 @@ def test_period_determiner_19():
     assert result == ('28.03.2019', '28.03.2019')
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_20():
     # если используется корректная форма к примеру "с 28 марта 2019",
     # то период определится как  с 28 марта 2019 года по сегодня
+    current_date = datetime.now()
+
     words_to_process = [
         'с',
         '28',
@@ -286,9 +324,12 @@ def test_period_determiner_20():
                               current_date.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_21():
     # если используется корректная форма к примеру "за n года",
     # то период определится как с даты ранее на 365 * n дней текущего дня
+    current_date = datetime.now()
+
     count_of_years: int = 3
     words_to_process = [
         'за',
@@ -305,9 +346,12 @@ def test_period_determiner_21():
                                         current_date.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_22():
     # если используется корректная форма к примеру "за n месяца",
     # то период определится как с даты ранее на 30 * n дней текущего дня
+    current_date = datetime.now()
+
     count_of_months: int = 2
     words_to_process = [
         'за',
@@ -324,8 +368,11 @@ def test_period_determiner_22():
                                         current_date.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_23():
     # если используется форма "с 2 по 17 июня"
+    current_date = datetime.now()
+
     count_of_months: int = 2
     words_to_process = [
         'с',
@@ -339,6 +386,7 @@ def test_period_determiner_23():
                       '17.01.{}'.format(current_date.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_24():
     # тест контроля максимального количества дней в периоде
     count_of_years: int = 2
@@ -351,9 +399,12 @@ def test_period_determiner_24():
     assert result == (ERROR_VALUE, ERROR_VALUE)
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_25():
     # если используется корректная форма к примеру "за n недель",
     # то период определится как с даты ранее на 7 * n дней текущего дня
+    current_date = datetime.now()
+
     count_of_weeks: int = 3
     words_to_process = [
         'за',
@@ -370,9 +421,12 @@ def test_period_determiner_25():
                                         current_date.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_26():
     # если используется корректная форма к примеру "за последние n дней",
     # то период определится как с даты ранее на n дней текущего дня
+    current_date = datetime.now()
+
     count_of_days: int = 30
     words_to_process = [
         'за',
@@ -390,6 +444,7 @@ def test_period_determiner_26():
                                         current_date.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_27():
     # когда используется только номер года и сам год
     words_to_process = [
@@ -401,9 +456,12 @@ def test_period_determiner_27():
     assert result == ('01.01.2020', '31.12.2020')
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_28():
     # если используется корректная форма "за неделю"
     # без указания количества недель
+    current_date = datetime.now()
+
     words_to_process = [
         'неделю'
     ]
@@ -417,9 +475,12 @@ def test_period_determiner_28():
                                         current_date.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_29():
     # если используется форма "за квартал",
     # без указания номера квартала, то имеем ввиду текущий квартал
+    current_date = datetime.now()
+
     words_to_process = [
         'квартал'
     ]
@@ -463,26 +524,33 @@ def test_period_determiner_29():
                                         d2.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_30():
     # если даты передана в формате d.m
+    current_date = datetime.now()
+
     words_to_process = [
         '8.1'
     ]
     result = period_determiner(words_to_process)
-    assert result == ('08.01.{}'.format(current_date.year), '08.01.{}'
-                      .format(current_date.year))
+    assert result == ('08.01.{}'.format(current_date.year),
+                      '08.01.{}'.format(current_date.year))
 
 
+@freeze_time('2021-11-23')
 def test_period_determiner_31():
     # если используется корректная форма к примеру "с 2019 года",
     # то период определится как с начала 2019 года по сегодня
+    current_date = datetime.now()
+
     words_to_process = [
         'с',
         '2019',
         'года'
     ]
     result = period_determiner(words_to_process)
-    assert result == ('01.01.2019', '{}.{}.{}'
+    assert result == ('01.01.2019',
+                      '{}.{}.{}'
                       .format(str(current_date.day).zfill(2),
                               str(current_date.month).zfill(2),
                               current_date.year))

--- a/tests/core_tests/test_utils/test_date_determining.py
+++ b/tests/core_tests/test_utils/test_date_determining.py
@@ -25,10 +25,7 @@ def test_period_determiner_1():
         'ныне'
     ]
     result = period_determiner(words_to_process)
-    assert result == ('01.03.2019', '{}.{}.{}'
-                      .format(str(current_date.day).zfill(2),
-                              str(current_date.month).zfill(2),
-                              current_date.year))
+    assert result == ('01.03.2019', current_date.strftime('%d.%m.%Y'))
 
 
 @freeze_time('2021-11-23')
@@ -45,10 +42,7 @@ def test_period_determiner_2():
         'день',
     ]
     result = period_determiner(words_to_process)
-    assert result == ('01.03.2019', '{}.{}.{}'
-                      .format(str(current_date.day).zfill(2),
-                              str(current_date.month).zfill(2),
-                              current_date.year))
+    assert result == ('01.03.2019', current_date.strftime('%d.%m.%Y'))
 
 
 @freeze_time('2021-11-23')
@@ -107,9 +101,7 @@ def test_period_determiner_5():
 
     assert result == (
         '01.{}.{}'.format(str(month).zfill(2), year),
-        '{}.{}.{}'.format(str(current_date.day).zfill(2),
-                          str(current_date.month).zfill(2),
-                          current_date.year)
+        current_date.strftime('%d.%m.%Y')
     )
 
 
@@ -128,10 +120,8 @@ def test_period_determiner_6():
     d = current_date - timedelta(days=delta_day)
 
     assert result == (
-        '{}.{}.{}'.format(str(d.day).zfill(2), str(d.month).zfill(2), d.year),
-        '{}.{}.{}'.format(str(current_date.day).zfill(2),
-                          str(current_date.month).zfill(2),
-                          current_date.year)
+        d.strftime('%d.%m.%Y'),
+        current_date.strftime('%d.%m.%Y')
     )
 
 
@@ -197,10 +187,7 @@ def test_period_determiner_11():
         '2020',
     ]
     result = period_determiner(words_to_process)
-    assert result == ('01.07.2020', '{}.{}.{}'
-                      .format(str(current_date.day).zfill(2),
-                              str(current_date.month).zfill(2),
-                              current_date.year))
+    assert result == ('01.07.2020', current_date.strftime('%d.%m.%Y'))
 
 
 @freeze_time('2021-11-23')
@@ -318,10 +305,7 @@ def test_period_determiner_20():
         'года'
     ]
     result = period_determiner(words_to_process)
-    assert result == ('28.03.2019', '{}.{}.{}'
-                      .format(str(current_date.day).zfill(2),
-                              str(current_date.month).zfill(2),
-                              current_date.year))
+    assert result == ('28.03.2019', current_date.strftime('%d.%m.%Y'))
 
 
 @freeze_time('2021-11-23')
@@ -338,12 +322,10 @@ def test_period_determiner_21():
     ]
     result = period_determiner(words_to_process)
     d1: datetime = current_date - timedelta(365 * count_of_years)
-    assert result == ('{}.{}.{}'.format(str(d1.day).zfill(2),
-                                        str(d1.month).zfill(2),
-                                        d1.year),
-                      '{}.{}.{}'.format(str(current_date.day).zfill(2),
-                                        str(current_date.month).zfill(2),
-                                        current_date.year))
+    assert result == (
+        d1.strftime('%d.%m.%Y'),
+        current_date.strftime('%d.%m.%Y')
+    )
 
 
 @freeze_time('2021-11-23')
@@ -360,12 +342,10 @@ def test_period_determiner_22():
     ]
     result = period_determiner(words_to_process)
     d1: datetime = current_date - timedelta(30 * count_of_months)
-    assert result == ('{}.{}.{}'.format(str(d1.day).zfill(2),
-                                        str(d1.month).zfill(2),
-                                        d1.year),
-                      '{}.{}.{}'.format(str(current_date.day).zfill(2),
-                                        str(current_date.month).zfill(2),
-                                        current_date.year))
+    assert result == (
+        d1.strftime('%d.%m.%Y'),
+        current_date.strftime('%d.%m.%Y')
+    )
 
 
 @freeze_time('2021-11-23')
@@ -413,12 +393,10 @@ def test_period_determiner_25():
     ]
     result = period_determiner(words_to_process)
     d1: datetime = current_date - timedelta(7 * count_of_weeks)
-    assert result == ('{}.{}.{}'.format(str(d1.day).zfill(2),
-                                        str(d1.month).zfill(2),
-                                        d1.year),
-                      '{}.{}.{}'.format(str(current_date.day).zfill(2),
-                                        str(current_date.month).zfill(2),
-                                        current_date.year))
+    assert result == (
+        d1.strftime('%d.%m.%Y'),
+        current_date.strftime('%d.%m.%Y')
+    )
 
 
 @freeze_time('2021-11-23')
@@ -436,12 +414,10 @@ def test_period_determiner_26():
     ]
     result = period_determiner(words_to_process)
     d1: datetime = current_date - timedelta(count_of_days)
-    assert result == ('{}.{}.{}'.format(str(d1.day).zfill(2),
-                                        str(d1.month).zfill(2),
-                                        d1.year),
-                      '{}.{}.{}'.format(str(current_date.day).zfill(2),
-                                        str(current_date.month).zfill(2),
-                                        current_date.year))
+    assert result == (
+        d1.strftime('%d.%m.%Y'),
+        current_date.strftime('%d.%m.%Y')
+    )
 
 
 @freeze_time('2021-11-23')
@@ -467,12 +443,10 @@ def test_period_determiner_28():
     ]
     result = period_determiner(words_to_process)
     d1: datetime = current_date - timedelta(7)
-    assert result == ('{}.{}.{}'.format(str(d1.day).zfill(2),
-                                        str(d1.month).zfill(2),
-                                        d1.year),
-                      '{}.{}.{}'.format(str(current_date.day).zfill(2),
-                                        str(current_date.month).zfill(2),
-                                        current_date.year))
+    assert result == (
+        d1.strftime('%d.%m.%Y'),
+        current_date.strftime('%d.%m.%Y')
+    )
 
 
 @freeze_time('2021-11-23')
@@ -516,12 +490,10 @@ def test_period_determiner_29():
         ) - timedelta(days=1)
 
     result = period_determiner(words_to_process, future_days_allowed=True)
-    assert result == ('{}.{}.{}'.format(str(d1.day).zfill(2),
-                                        str(d1.month).zfill(2),
-                                        d1.year),
-                      '{}.{}.{}'.format(str(d2.day).zfill(2),
-                                        str(d2.month).zfill(2),
-                                        d2.year))
+    assert result == (
+        d1.strftime('%d.%m.%Y'),
+        d2.strftime('%d.%m.%Y')
+    )
 
 
 @freeze_time('2021-11-23')
@@ -549,11 +521,7 @@ def test_period_determiner_31():
         'года'
     ]
     result = period_determiner(words_to_process)
-    assert result == ('01.01.2019',
-                      '{}.{}.{}'
-                      .format(str(current_date.day).zfill(2),
-                              str(current_date.month).zfill(2),
-                              current_date.year))
+    assert result == ('01.01.2019', current_date.strftime('%d.%m.%Y'))
 
 
 def test_extract_words_describing_period_1():


### PR DESCRIPTION
Добавлено использование декоратора freeze_time, который меняет текущее системное время для объектов datetime на указанное в декораторе. 

Это нужно для того, чтобы тесты были предсказуемыми. Тесты падали, потому что не был включен флаг future_days_allowed и так тесты получались имели побочный эффект в виде каждый день новой текущего даты.
