### PR TITLE
added init message_handlers to main init

### DIFF
--- a/smart_kit/resources/__init__.py
+++ b/smart_kit/resources/__init__.py
@@ -169,6 +169,7 @@ class SmartAppResources(BaseConfig):
         self.init_history_formatters()
         self.init_db_adapters()
         self.init_classifiers()
+        self.init_message_handlers()
 
     def init_field_requirements(self):
         frd.field_requirements[None] = frd.FieldRequirement


### PR DESCRIPTION
Забыли добавить вызов `init_message_handlers` в главном `init` всех ресурсов