### PR TITLE
fix masking

### DIFF
--- a/core/logging/logger_utils.py
+++ b/core/logging/logger_utils.py
@@ -58,7 +58,8 @@ class LoggerMessageCreator:
         params = params or {}
         if user:
             cls.update_user_params(user, params)
-        masking(pickle_deepcopy(params))
+        params = pickle_deepcopy(params)
+        masking(params)
         cls.update_other_params(user, params, cls_name, log_store_for)
         return params
 


### PR DESCRIPTION
Пофиксил ошибку при маскировании: маскируется/мутируется скопированный словарь параметров, который никуда не идёт.  Теперь копия словаря пробрасывается дальше в логирование