### PR TITLE
bugfix with jinja dependency markupsafe (jinja2 2.10.1 -> 3.0.3)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "dawg==0.8.0",
         "dill==0.3.3",
         "ics==0.6",
-        "Jinja2==2.10.1",
+        "Jinja2==3.0.3",
         "keras==2.6.0",
         "lazy",
         "nltk==3.5",


### PR DESCRIPTION
Бибилиотека Jinja2 имеет зависимость MarkupSafe, которая [недавно обновилась](https://github.com/pallets/markupsafe/issues/282) и теперь [на тестах падает ошибка](https://github.com/sberdevices/smart_app_framework/runs/5269300600?check_suite_focus=true). Так же это может заафектить все новые сборки с фреймворком, потому что у нас в зависимостях не указана конкретная версия MarkupSafe.

Этот пр обновляет версию Jinja2 до последней 3.0.3 чтобы исправить этот баг.