### PR TITLE
skip rendering log params if level less than logger level

### DIFF
--- a/core/logging/logger_utils.py
+++ b/core/logging/logger_utils.py
@@ -73,6 +73,8 @@ def log(message, user=None, params=None, level="INFO", exc_info=None, log_store_
         previous_frame = current_frame.f_back
         module_name = previous_frame.f_globals["__name__"]
         logger = logging.getLogger(module_name)
+        if not logger.isEnabledFor(level_name):
+            return
         instance = previous_frame.f_locals.get('self', None)
 
         from smart_kit.configs import get_app_config


### PR DESCRIPTION
Добавил проверку уровня логирования перед тем как рендерить параметры

Это нужно для того чтобы ускорить работу функции - не будем рендерть параметры (функция маскирования съедает слишком много времени) 