### PR TITLE
fix metrics

### DIFF
--- a/smart_kit/utils/monitoring.py
+++ b/smart_kit/utils/monitoring.py
@@ -1,6 +1,6 @@
 from core.logging.logger_constants import KEY_NAME
 from core.logging.logger_utils import log
-from core.monitoring.monitoring import Monitoring
+from core.monitoring.monitoring import monitoring
 
 
 def _filter_monitoring_msg(msg):
@@ -25,7 +25,7 @@ def silence_it(func):
     return wrap
 
 
-class Metrics(Monitoring):
+class Metrics:
 
     @silence_it
     def init_metrics(self, app_name):
@@ -39,7 +39,7 @@ class Metrics(Monitoring):
                                             "Incoming message validation error.")
 
     def _get_or_create_counter(self, monitoring_msg, descr, labels=()):
-        counter = self.get_counter(monitoring_msg, descr, labels)
+        counter = monitoring.get_counter(monitoring_msg, descr, labels)
         if counter is None:
             raise MetricDisabled('counter disabled')
         return counter
@@ -182,22 +182,22 @@ class Metrics(Monitoring):
     @silence_it
     def sampling_load_time(self, app_name, value):
         monitoring_msg = "{}_load_time".format(app_name)
-        self.got_histogram_observe(_filter_monitoring_msg(monitoring_msg), value)
+        monitoring.got_histogram_observe(_filter_monitoring_msg(monitoring_msg), value)
 
     @silence_it
     def sampling_script_time(self, app_name, value):
         monitoring_msg = "{}_script_time".format(app_name)
-        self.got_histogram_observe(_filter_monitoring_msg(monitoring_msg), value)
+        monitoring.got_histogram_observe(_filter_monitoring_msg(monitoring_msg), value)
 
     @silence_it
     def sampling_save_time(self, app_name, value):
         monitoring_msg = "{}_save_time".format(app_name)
-        self.got_histogram_observe(_filter_monitoring_msg(monitoring_msg), value)
+        monitoring.got_histogram_observe(_filter_monitoring_msg(monitoring_msg), value)
 
     @silence_it
     def sampling_mq_waiting_time(self, app_name, value):
         monitoring_msg = "{}_mq_waiting_time".format(app_name)
-        self.got_histogram_observe(_filter_monitoring_msg(monitoring_msg), value)
+        monitoring.got_histogram_observe(_filter_monitoring_msg(monitoring_msg), value)
 
 
 smart_kit_metrics = Metrics()


### PR DESCRIPTION
Поменял наследование метрик от мониторинга на использование синглтон инстанса мониторинга

Это нужно для того, чтобы не дублировать инстансы метрики и иметь один полный инстанс мониторинга с данными а класс метрик использовать просто как фасадный класс к мониторингу