### PR TITLE
DPNLPF-1570: remove text_preprocessing_result logs from handlers that do not have message

### DIFF
--- a/smart_kit/handlers/handle_close_app.py
+++ b/smart_kit/handlers/handle_close_app.py
@@ -15,8 +15,11 @@ class HandlerCloseApp(HandlerBase):
         super().run(payload, user)
         text_preprocessing_result = TextPreprocessingResult(payload.get("message", {}))
         params = {
-            log_const.KEY_NAME: "HandlerCloseApp",
-            "tpr_str": str(text_preprocessing_result.raw)
+            log_const.KEY_NAME: "HandlerCloseApp"
         }
         self._clear_current_scenario.run(user, text_preprocessing_result)
-        log("HandlerCloseApp with text preprocessing result", user, params)
+        if payload.get("message"):
+            params["tpr_str"] = str(text_preprocessing_result.raw)
+            log("HandlerCloseApp with text preprocessing result", user, params)
+        else:
+            log("HandlerCloseApp without text preprocessing result", user, params)

--- a/smart_kit/handlers/handle_close_app.py
+++ b/smart_kit/handlers/handle_close_app.py
@@ -20,6 +20,4 @@ class HandlerCloseApp(HandlerBase):
         self._clear_current_scenario.run(user, text_preprocessing_result)
         if payload.get("message"):
             params["tpr_str"] = str(text_preprocessing_result.raw)
-            log("HandlerCloseApp with text preprocessing result", user, params)
-        else:
-            log("HandlerCloseApp without text preprocessing result", user, params)
+        log("HandlerCloseApp with text preprocessing result", user, params)

--- a/smart_kit/handlers/handle_respond.py
+++ b/smart_kit/handlers/handle_respond.py
@@ -44,10 +44,9 @@ class HandlerRespond(HandlerBase):
 
         smart_kit_metrics.counter_incoming(self.app_name, user.message.message_name, self.__class__.__name__, user)
 
-        text_preprocessing_result = None
-        if payload.get("message"):
-            text_preprocessing_result = TextPreprocessingResult(payload["message"])
+        text_preprocessing_result = TextPreprocessingResult(payload.get("message", {}))
 
+        if payload.get("message"):
             params = {
                 log_const.KEY_NAME: log_const.NORMALIZED_TEXT_VALUE,
                 "normalized_text": str(text_preprocessing_result.raw),

--- a/smart_kit/handlers/handle_respond.py
+++ b/smart_kit/handlers/handle_respond.py
@@ -42,15 +42,17 @@ class HandlerRespond(HandlerBase):
         else:
             log("HandlerRespond with action %(action_name)s started without callback", user, params)
 
-        text_preprocessing_result = TextPreprocessingResult(payload.get("message", {}))
-
         smart_kit_metrics.counter_incoming(self.app_name, user.message.message_name, self.__class__.__name__, user)
 
-        params = {
-            log_const.KEY_NAME: log_const.NORMALIZED_TEXT_VALUE,
-            "normalized_text": str(text_preprocessing_result.raw),
-        }
-        log("text preprocessing result: '%(normalized_text)s'", user, params, level="DEBUG")
+        text_preprocessing_result = None
+        if payload.get("message"):
+            text_preprocessing_result = TextPreprocessingResult(payload["message"])
+
+            params = {
+                log_const.KEY_NAME: log_const.NORMALIZED_TEXT_VALUE,
+                "normalized_text": str(text_preprocessing_result.raw),
+            }
+            log("text preprocessing result: '%(normalized_text)s'", user, params, level="DEBUG")
 
         action = user.descriptions["external_actions"][action_name]
         return action.run(user, text_preprocessing_result, action_params)

--- a/smart_kit/handlers/handle_server_action.py
+++ b/smart_kit/handlers/handle_server_action.py
@@ -35,4 +35,4 @@ class HandlerServerAction(HandlerBase):
 
         action_id = self.get_action_name(payload, user)
         action = user.descriptions["external_actions"][action_id]
-        return action.run(user, TextPreprocessingResult({}), action_params)
+        return action.run(user, None, action_params)

--- a/smart_kit/handlers/handle_server_action.py
+++ b/smart_kit/handlers/handle_server_action.py
@@ -35,4 +35,4 @@ class HandlerServerAction(HandlerBase):
 
         action_id = self.get_action_name(payload, user)
         action = user.descriptions["external_actions"][action_id]
-        return action.run(user, None, action_params)
+        return action.run(user, TextPreprocessingResult({}), action_params)

--- a/smart_kit/handlers/handler_run_app.py
+++ b/smart_kit/handlers/handler_run_app.py
@@ -29,5 +29,5 @@ class HandlerRunApp(HandlerBase):
         return answer
 
     def _handle_base(self, user):
-        answer, is_answer_found = self.dialogue_manager.run(None, user)
+        answer, is_answer_found = self.dialogue_manager.run(TextPreprocessingResult({}), user)
         return answer or []

--- a/smart_kit/handlers/handler_run_app.py
+++ b/smart_kit/handlers/handler_run_app.py
@@ -1,0 +1,33 @@
+# coding: utf-
+
+import scenarios.logging.logger_constants as log_const
+from core.logging.logger_utils import log
+from core.text_preprocessing.preprocessing_result import TextPreprocessingResult
+
+from smart_kit.handlers.handler_base import HandlerBase
+
+
+class HandlerRunApp(HandlerBase):
+
+    def __init__(self, app_name, dialogue_manager):
+        super().__init__(app_name)
+        log(
+            f"{self.__class__.__name__}.__init__ started.", params={log_const.KEY_NAME: log_const.STARTUP_VALUE}
+        )
+        self.dialogue_manager = dialogue_manager
+        log(
+            f"{self.__class__.__name__}.__init__ finished.", params={log_const.KEY_NAME: log_const.STARTUP_VALUE}
+        )
+
+    def run(self, payload, user):
+        super().run(payload, user)
+
+        params = {log_const.KEY_NAME: "handling_run_app"}
+        log(f"{self.__class__.__name__}.run started", user, params)
+
+        answer = self._handle_base(user)
+        return answer
+
+    def _handle_base(self, user):
+        answer, is_answer_found = self.dialogue_manager.run(None, user)
+        return answer or []

--- a/smart_kit/handlers/handler_text.py
+++ b/smart_kit/handlers/handler_text.py
@@ -22,14 +22,13 @@ class HandlerText(HandlerBase):
     def run(self, payload, user):
         super().run(payload, user)
 
-        text_preprocessing_result = TextPreprocessingResult(payload.get("message", {}))
+        text_preprocessing_result = TextPreprocessingResult(payload["message"])
 
-        if payload.get("message"):
-            params = {
-                log_const.KEY_NAME: log_const.NORMALIZED_TEXT_VALUE,
-                "normalized_text": str(text_preprocessing_result.raw),
-            }
-            log("text preprocessing result: '%(normalized_text)s'", user, params)
+        params = {
+            log_const.KEY_NAME: log_const.NORMALIZED_TEXT_VALUE,
+            "normalized_text": str(text_preprocessing_result.raw),
+        }
+        log("text preprocessing result: '%(normalized_text)s'", user, params)
 
         answer = self._handle_base(text_preprocessing_result, user)
         return answer

--- a/smart_kit/handlers/handler_text.py
+++ b/smart_kit/handlers/handler_text.py
@@ -21,13 +21,16 @@ class HandlerText(HandlerBase):
 
     def run(self, payload, user):
         super().run(payload, user)
-        text_preprocessing_result = TextPreprocessingResult(payload.get("message", {}))
 
-        params = {
-            log_const.KEY_NAME: log_const.NORMALIZED_TEXT_VALUE,
-            "normalized_text": str(text_preprocessing_result.raw),
-        }
-        log("text preprocessing result: '%(normalized_text)s'", user, params)
+        text_preprocessing_result = None
+        if payload.get("message"):
+            text_preprocessing_result = TextPreprocessingResult(payload["message"])
+
+            params = {
+                log_const.KEY_NAME: log_const.NORMALIZED_TEXT_VALUE,
+                "normalized_text": str(text_preprocessing_result.raw),
+            }
+            log("text preprocessing result: '%(normalized_text)s'", user, params)
 
         answer = self._handle_base(text_preprocessing_result, user)
         return answer

--- a/smart_kit/handlers/handler_text.py
+++ b/smart_kit/handlers/handler_text.py
@@ -22,10 +22,9 @@ class HandlerText(HandlerBase):
     def run(self, payload, user):
         super().run(payload, user)
 
-        text_preprocessing_result = None
-        if payload.get("message"):
-            text_preprocessing_result = TextPreprocessingResult(payload["message"])
+        text_preprocessing_result = TextPreprocessingResult(payload.get("message", {}))
 
+        if payload.get("message"):
             params = {
                 log_const.KEY_NAME: log_const.NORMALIZED_TEXT_VALUE,
                 "normalized_text": str(text_preprocessing_result.raw),

--- a/smart_kit/models/smartapp_model.py
+++ b/smart_kit/models/smartapp_model.py
@@ -9,6 +9,7 @@ from core.utils.exception_handlers import exc_handler
 
 import scenarios.logging.logger_constants as log_const
 from smart_kit.handlers.handle_close_app import HandlerCloseApp
+from smart_kit.handlers.handler_run_app import HandlerRunApp
 from smart_kit.names.message_names import MESSAGE_TO_SKILL, LOCAL_TIMEOUT, RUN_APP, SERVER_ACTION, CLOSE_APP
 from smart_kit.handlers.handle_respond import HandlerRespond
 from smart_kit.handlers.handler_text import HandlerText
@@ -32,11 +33,9 @@ class SmartAppModel:
         self.dialogue_manager = dialogue_manager_cls(scenario_descriptions=self.scenario_descriptions,
                                                      app_name=self.app_name)
 
-        handler_text = HandlerText(self.app_name, dialogue_manager=self.dialogue_manager)
-
         self._handlers = {
-            MESSAGE_TO_SKILL: handler_text,
-            RUN_APP: handler_text,
+            MESSAGE_TO_SKILL: HandlerText(self.app_name, dialogue_manager=self.dialogue_manager),
+            RUN_APP: HandlerRunApp(self.app_name, dialogue_manager=self.dialogue_manager),
             LOCAL_TIMEOUT: HandlerTimeout(self.app_name),
             SERVER_ACTION: HandlerServerAction(self.app_name),
             CLOSE_APP: HandlerCloseApp(self.app_name)


### PR DESCRIPTION
Убрал создание и передачу text_preprocessing_result из handlers, которые не имеют message.

Таким образом, handlers не будут логировать бесполезную информацию о тексте, которого нет, а также не будут тратить время на создание объектов TextPreprocessingResult.